### PR TITLE
Add repository URL to pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: dio_interceptor_seq
 description: An interceptor for the DIO client that sends request, response, and error logs to Seq.
 version: 0.0.1
-homepage: asd
+homepage: https://github.com/Altamir/dio_interceptor_seq
 
 environment:
   sdk: '>=2.18.2 <3.0.0'


### PR DESCRIPTION
This PR adds the repository URL to the pubspec.yaml file. This addition makes it easier for users to find the project's source code and contribute improvements or bug fixes.

Changes made:

* Added the repository field to the pubspec.yaml file, pointing to the repository URL.

By including the repository link in the pubspec.yaml, we are enhancing the user experience and making it easier to access the source code for potential contributions.